### PR TITLE
v2.2

### DIFF
--- a/src/Carbonated.Data.SqlServer.Tests/BulkSaveTest.cs
+++ b/src/Carbonated.Data.SqlServer.Tests/BulkSaveTest.cs
@@ -20,6 +20,12 @@ internal class BulkSaveTest
         connector = new SqlServerDbConnector(TestConnectionString);
     }
 
+    [TearDown]
+    public void TearDown()
+    {
+        connector.Dispose();
+    }
+
     [Test]
     public void SaveUsingEntityDataReaderInPlaceOfTable()
     {

--- a/src/Carbonated.Data.SqlServer.Tests/Carbonated.Data.SqlServer.Tests.csproj
+++ b/src/Carbonated.Data.SqlServer.Tests/Carbonated.Data.SqlServer.Tests.csproj
@@ -7,10 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NUnit" Version="4.0.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Carbonated.Data.SqlServer.Tests/QueryScalarTests.cs
+++ b/src/Carbonated.Data.SqlServer.Tests/QueryScalarTests.cs
@@ -16,294 +16,409 @@ public class QueryScalarTests
         db = new SqlServerDbConnector(TestConnectionString);
     }
 
+    [TearDown]
+    public void TearDown()
+    {
+        db.Dispose();
+    }
+
+
     private string Select(string field, int id) => $"select [{field}] from type_test where id = {id}";
 
     [Test]
     public void QueryScalarBool()
     {
-        Assert.IsFalse(db.QueryScalar<bool>(Select("bool", 1)));
-        Assert.IsFalse(db.QueryScalar<bool>(Select("bool", 2)));
-        Assert.IsTrue(db.QueryScalar<bool>(Select("bool", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<bool>(Select("bool", 1)), Is.False);
+            Assert.That(db.QueryScalar<bool>(Select("bool", 2)), Is.False);
+            Assert.That(db.QueryScalar<bool>(Select("bool", 3)), Is.True);
+        });
     }
 
     [Test]
     public void QueryScalarByte()
     {
-        Assert.AreEqual(0, db.QueryScalar<byte>(Select("byte", 1)));
-        Assert.AreEqual(0, db.QueryScalar<byte>(Select("byte", 2)));
-        Assert.AreEqual(1, db.QueryScalar<byte>(Select("byte", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<byte>(Select("byte", 1)), Is.EqualTo(0));
+            Assert.That(db.QueryScalar<byte>(Select("byte", 2)), Is.EqualTo(0));
+            Assert.That(db.QueryScalar<byte>(Select("byte", 3)), Is.EqualTo(1));
+        });
     }
 
     [Test]
     public void QueryScalarShort()
     {
-        Assert.AreEqual(0, db.QueryScalar<short>(Select("short", 1)));
-        Assert.AreEqual(0, db.QueryScalar<short>(Select("short", 2)));
-        Assert.AreEqual(2, db.QueryScalar<short>(Select("short", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<short>(Select("short", 1)), Is.EqualTo(0));
+            Assert.That(db.QueryScalar<short>(Select("short", 2)), Is.EqualTo(0));
+            Assert.That(db.QueryScalar<short>(Select("short", 3)), Is.EqualTo(2));
+        });
     }
 
     [Test]
     public void QueryScalarInt()
     {
-        Assert.AreEqual(0, db.QueryScalar<int>(Select("int", 1)));
-        Assert.AreEqual(0, db.QueryScalar<int>(Select("int", 2)));
-        Assert.AreEqual(3, db.QueryScalar<int>(Select("int", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<int>(Select("int", 1)), Is.EqualTo(0));
+            Assert.That(db.QueryScalar<int>(Select("int", 2)), Is.EqualTo(0));
+            Assert.That(db.QueryScalar<int>(Select("int", 3)), Is.EqualTo(3));
+        });
     }
 
     [Test]
     public void QueryScalarLong()
     {
-        Assert.AreEqual(0, db.QueryScalar<long>(Select("long", 1)));
-        Assert.AreEqual(0, db.QueryScalar<long>(Select("long", 2)));
-        Assert.AreEqual(5, db.QueryScalar<long>(Select("long", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<long>(Select("long", 1)), Is.EqualTo(0));
+            Assert.That(db.QueryScalar<long>(Select("long", 2)), Is.EqualTo(0));
+            Assert.That(db.QueryScalar<long>(Select("long", 3)), Is.EqualTo(5));
+        });
     }
 
     [Test]
     public void QueryScalarFloat()
     {
-        Assert.AreEqual(0, db.QueryScalar<float>(Select("float", 1)));
-        Assert.AreEqual(0, db.QueryScalar<float>(Select("float", 2)));
-        Assert.AreEqual(8.13f, db.QueryScalar<float>(Select("float", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<float>(Select("float", 1)), Is.EqualTo(0));
+            Assert.That(db.QueryScalar<float>(Select("float", 2)), Is.EqualTo(0));
+            Assert.That(db.QueryScalar<float>(Select("float", 3)), Is.EqualTo(8.13f));
+        });
     }
 
     [Test]
     public void QueryScalarDouble()
     {
-        Assert.AreEqual(0, db.QueryScalar<double>(Select("double", 1)));
-        Assert.AreEqual(0, db.QueryScalar<double>(Select("double", 2)));
-        Assert.AreEqual(21.34, db.QueryScalar<double>(Select("double", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<double>(Select("double", 1)), Is.EqualTo(0));
+            Assert.That(db.QueryScalar<double>(Select("double", 2)), Is.EqualTo(0));
+            Assert.That(db.QueryScalar<double>(Select("double", 3)), Is.EqualTo(21.34));
+        });
     }
 
     [Test]
     public void QueryScalarDecimal()
     {
-        Assert.AreEqual(0, db.QueryScalar<decimal>(Select("decimal", 1)));
-        Assert.AreEqual(0, db.QueryScalar<decimal>(Select("decimal", 2)));
-        Assert.AreEqual(55.89m, db.QueryScalar<decimal>(Select("decimal", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<decimal>(Select("decimal", 1)), Is.EqualTo(0));
+            Assert.That(db.QueryScalar<decimal>(Select("decimal", 2)), Is.EqualTo(0));
+            Assert.That(db.QueryScalar<decimal>(Select("decimal", 3)), Is.EqualTo(55.89m));
+        });
     }
 
     [Test]
     public void QueryScalarDateTime()
     {
-        Assert.AreEqual(DateTime.MinValue, db.QueryScalar<DateTime>(Select("DateTime", 1)));
-        Assert.AreEqual(new DateTime(1753, 1, 1, 0, 0, 0), db.QueryScalar<DateTime>(Select("DateTime", 2)));
-        Assert.AreEqual(new DateTime(2018, 4, 2, 13, 14, 15), db.QueryScalar<DateTime>(Select("DateTime", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<DateTime>(Select("DateTime", 1)), Is.EqualTo(DateTime.MinValue));
+            Assert.That(db.QueryScalar<DateTime>(Select("DateTime", 2)), Is.EqualTo(new DateTime(1753, 1, 1, 0, 0, 0)));
+            Assert.That(db.QueryScalar<DateTime>(Select("DateTime", 3)), Is.EqualTo(new DateTime(2018, 4, 2, 13, 14, 15)));
+        });
     }
 
     [Test]
     public void QueryScalarDateTimeStoredAsDateTime2()
     {
-        Assert.AreEqual(DateTime.MinValue, db.QueryScalar<DateTime>(Select("DateTime2", 1)));
-        Assert.AreEqual(DateTime.MinValue, db.QueryScalar<DateTime>(Select("DateTime2", 2)));
-        Assert.AreEqual(new DateTime(2023, 8, 11, 14, 9, 15), db.QueryScalar<DateTime>(Select("DateTime2", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<DateTime>(Select("DateTime2", 1)), Is.EqualTo(DateTime.MinValue));
+            Assert.That(db.QueryScalar<DateTime>(Select("DateTime2", 2)), Is.EqualTo(DateTime.MinValue));
+            Assert.That(db.QueryScalar<DateTime>(Select("DateTime2", 3)), Is.EqualTo(new DateTime(2023, 8, 11, 14, 9, 15)));
+        });
     }
 
     [Test]
     public void QueryScalarDateOnly()
     {
-        Assert.AreEqual(DateOnly.MinValue, db.QueryScalar<DateOnly>(Select("Date", 1)));
-        Assert.AreEqual(DateOnly.MinValue, db.QueryScalar<DateOnly>(Select("Date", 2)));
-        Assert.AreEqual(new DateOnly(2023, 8, 11), db.QueryScalar<DateOnly>(Select("Date", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<DateOnly>(Select("Date", 1)), Is.EqualTo(DateOnly.MinValue));
+            Assert.That(db.QueryScalar<DateOnly>(Select("Date", 2)), Is.EqualTo(DateOnly.MinValue));
+            Assert.That(db.QueryScalar<DateOnly>(Select("Date", 3)), Is.EqualTo(new DateOnly(2023, 8, 11)));
+        });
     }
 
     [Test]
     public void QueryScalarTimeOnly()
     {
-        Assert.AreEqual(TimeOnly.MinValue, db.QueryScalar<TimeOnly>(Select("Time", 1)));
-        Assert.AreEqual(TimeOnly.MinValue, db.QueryScalar<TimeOnly>(Select("Time", 2)));
-        Assert.AreEqual(new TimeOnly(14, 9, 15), db.QueryScalar<TimeOnly>(Select("Time", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<TimeOnly>(Select("Time", 1)), Is.EqualTo(TimeOnly.MinValue));
+            Assert.That(db.QueryScalar<TimeOnly>(Select("Time", 2)), Is.EqualTo(TimeOnly.MinValue));
+            Assert.That(db.QueryScalar<TimeOnly>(Select("Time", 3)), Is.EqualTo(new TimeOnly(14, 9, 15)));
+        });
     }
 
     [Test]
     public void QueryScalarGuidStoredAsString()
     {
-        Assert.AreEqual(Guid.Empty, db.QueryScalar<Guid>(Select("guid_as_string", 1)));
-        Assert.AreEqual(Guid.Empty, db.QueryScalar<Guid>(Select("guid_as_string", 2)));
-        Assert.AreEqual(new Guid("7ca43d156e8749dfbaffdb241d0d494c"), db.QueryScalar<Guid>(Select("guid_as_string", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<Guid>(Select("guid_as_string", 1)), Is.EqualTo(Guid.Empty));
+            Assert.That(db.QueryScalar<Guid>(Select("guid_as_string", 2)), Is.EqualTo(Guid.Empty));
+            Assert.That(db.QueryScalar<Guid>(Select("guid_as_string", 3)), Is.EqualTo(new Guid("7ca43d156e8749dfbaffdb241d0d494c")));
+        });
     }
 
     [Test]
     public void QueryScalarGuidStoredAsUniqueIdentifier()
     {
-        Assert.AreEqual(Guid.Empty, db.QueryScalar<Guid>(Select("guid_as_uniqueid", 1)));
-        Assert.AreEqual(Guid.Empty, db.QueryScalar<Guid>(Select("guid_as_uniqueid", 2)));
-        Assert.AreEqual(new Guid("7ca43d156e8749dfbaffdb241d0d494c"), db.QueryScalar<Guid>(Select("guid_as_uniqueid", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<Guid>(Select("guid_as_uniqueid", 1)), Is.EqualTo(Guid.Empty));
+            Assert.That(db.QueryScalar<Guid>(Select("guid_as_uniqueid", 2)), Is.EqualTo(Guid.Empty));
+            Assert.That(db.QueryScalar<Guid>(Select("guid_as_uniqueid", 3)), Is.EqualTo(new Guid("7ca43d156e8749dfbaffdb241d0d494c")));
+        });
     }
 
     [Test]
     public void QueryScalarChar()
     {
-        Assert.AreEqual('\0', db.QueryScalar<char>(Select("char", 1)));
-        Assert.AreEqual('\0', db.QueryScalar<char>(Select("char", 2)));
-        Assert.AreEqual('c', db.QueryScalar<char>(Select("char", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<char>(Select("char", 1)), Is.EqualTo('\0'));
+            Assert.That(db.QueryScalar<char>(Select("char", 2)), Is.EqualTo('\0'));
+            Assert.That(db.QueryScalar<char>(Select("char", 3)), Is.EqualTo('c'));
+        });
     }
 
     [Test]
     public void QueryScalarString()
     {
-        Assert.AreEqual(null, db.QueryScalar<string>(Select("string", 1)));
-        Assert.AreEqual("", db.QueryScalar<string>(Select("string", 2)));
-        Assert.AreEqual("str", db.QueryScalar<string>(Select("string", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<string>(Select("string", 1)), Is.EqualTo(null));
+            Assert.That(db.QueryScalar<string>(Select("string", 2)), Is.EqualTo(""));
+            Assert.That(db.QueryScalar<string>(Select("string", 3)), Is.EqualTo("str"));
+        });
     }
 
     [Test]
     public void QueryScalarByteArray()
     {
-        Assert.AreEqual(null, db.QueryScalar<byte[]>(Select("byte_array", 1)));
-        Assert.AreEqual(null, db.QueryScalar<byte[]>(Select("byte_array", 2)));
-        Assert.AreEqual(new byte[] { 0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10 }, db.QueryScalar<byte[]>(Select("byte_array", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<byte[]>(Select("byte_array", 1)), Is.EqualTo(null));
+            Assert.That(db.QueryScalar<byte[]>(Select("byte_array", 2)), Is.EqualTo(null));
+            Assert.That(db.QueryScalar<byte[]>(Select("byte_array", 3)), Is.EqualTo(new byte[] { 0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10 }));
+        });
     }
 
     [Test]
     public void QueryScalarIntEnum()
     {
-        Assert.AreEqual(Numbers.Zero, db.QueryScalar<Numbers>(Select("int_enum", 1)));
-        Assert.AreEqual(Numbers.Zero, db.QueryScalar<Numbers>(Select("int_enum", 2)));
-        Assert.AreEqual(Numbers.Three, db.QueryScalar<Numbers>(Select("int_enum", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<Numbers>(Select("int_enum", 1)), Is.EqualTo(Numbers.Zero));
+            Assert.That(db.QueryScalar<Numbers>(Select("int_enum", 2)), Is.EqualTo(Numbers.Zero));
+            Assert.That(db.QueryScalar<Numbers>(Select("int_enum", 3)), Is.EqualTo(Numbers.Three));
+        });
     }
 
     [Test]
     public void QueryScalarStringEnum()
     {
-        Assert.AreEqual(Colors.Red, db.QueryScalar<Colors>(Select("string_enum", 1)));
-        Assert.AreEqual(Colors.Red, db.QueryScalar<Colors>(Select("string_enum", 2)));
-        Assert.AreEqual(Colors.Green, db.QueryScalar<Colors>(Select("string_enum", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<Colors>(Select("string_enum", 1)), Is.EqualTo(Colors.Red));
+            Assert.That(db.QueryScalar<Colors>(Select("string_enum", 2)), Is.EqualTo(Colors.Red));
+            Assert.That(db.QueryScalar<Colors>(Select("string_enum", 3)), Is.EqualTo(Colors.Green));
+        });
     }
 
     [Test]
     public void QueryScalarNullableBool()
     {
-        Assert.IsNull(db.QueryScalar<bool?>(Select("bool", 1)));
-        Assert.IsFalse(db.QueryScalar<bool?>(Select("bool", 2)));
-        Assert.IsTrue(db.QueryScalar<bool?>(Select("bool", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<bool?>(Select("bool", 1)), Is.Null);
+            Assert.That(db.QueryScalar<bool?>(Select("bool", 2)), Is.False);
+            Assert.That(db.QueryScalar<bool?>(Select("bool", 3)), Is.True);
+        });
     }
 
     [Test]
     public void QueryScalarNullableByte()
     {
-        Assert.AreEqual(null, db.QueryScalar<byte?>(Select("byte", 1)));
-        Assert.AreEqual(0, db.QueryScalar<byte?>(Select("byte", 2)));
-        Assert.AreEqual(1, db.QueryScalar<byte?>(Select("byte", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<byte?>(Select("byte", 1)), Is.EqualTo(null));
+            Assert.That(db.QueryScalar<byte?>(Select("byte", 2)), Is.EqualTo(0));
+            Assert.That(db.QueryScalar<byte?>(Select("byte", 3)), Is.EqualTo(1));
+        });
     }
 
     [Test]
     public void QueryScalarNullableShort()
     {
-        Assert.AreEqual(null, db.QueryScalar<short?>(Select("short", 1)));
-        Assert.AreEqual(0, db.QueryScalar<short?>(Select("short", 2)));
-        Assert.AreEqual(2, db.QueryScalar<short?>(Select("short", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<short?>(Select("short", 1)), Is.EqualTo(null));
+            Assert.That(db.QueryScalar<short?>(Select("short", 2)), Is.EqualTo(0));
+            Assert.That(db.QueryScalar<short?>(Select("short", 3)), Is.EqualTo(2));
+        });
     }
 
     [Test]
     public void QueryScalarNullableInt()
     {
-        Assert.AreEqual(null, db.QueryScalar<int?>(Select("int", 1)));
-        Assert.AreEqual(0, db.QueryScalar<int?>(Select("int", 2)));
-        Assert.AreEqual(3, db.QueryScalar<int?>(Select("int", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<int?>(Select("int", 1)), Is.EqualTo(null));
+            Assert.That(db.QueryScalar<int?>(Select("int", 2)), Is.EqualTo(0));
+            Assert.That(db.QueryScalar<int?>(Select("int", 3)), Is.EqualTo(3));
+        });
     }
 
     [Test]
     public void QueryScalarNullableLong()
     {
-        Assert.AreEqual(null, db.QueryScalar<long?>(Select("long", 1)));
-        Assert.AreEqual(0, db.QueryScalar<long?>(Select("long", 2)));
-        Assert.AreEqual(5, db.QueryScalar<long?>(Select("long", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<long?>(Select("long", 1)), Is.EqualTo(null));
+            Assert.That(db.QueryScalar<long?>(Select("long", 2)), Is.EqualTo(0));
+            Assert.That(db.QueryScalar<long?>(Select("long", 3)), Is.EqualTo(5));
+        });
     }
 
     [Test]
     public void QueryScalarNullableFloat()
     {
-        Assert.AreEqual(null, db.QueryScalar<float?>(Select("float", 1)));
-        Assert.AreEqual(0, db.QueryScalar<float?>(Select("float", 2)));
-        Assert.AreEqual(8.13f, db.QueryScalar<float?>(Select("float", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<float?>(Select("float", 1)), Is.EqualTo(null));
+            Assert.That(db.QueryScalar<float?>(Select("float", 2)), Is.EqualTo(0));
+            Assert.That(db.QueryScalar<float?>(Select("float", 3)), Is.EqualTo(8.13f));
+        });
     }
 
     [Test]
     public void QueryScalarNullableDouble()
     {
-        Assert.AreEqual(null, db.QueryScalar<double?>(Select("double", 1)));
-        Assert.AreEqual(0, db.QueryScalar<double?>(Select("double", 2)));
-        Assert.AreEqual(21.34, db.QueryScalar<double?>(Select("double", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<double?>(Select("double", 1)), Is.EqualTo(null));
+            Assert.That(db.QueryScalar<double?>(Select("double", 2)), Is.EqualTo(0));
+            Assert.That(db.QueryScalar<double?>(Select("double", 3)), Is.EqualTo(21.34));
+        });
     }
 
     [Test]
     public void QueryScalarNullableDecimal()
     {
-        Assert.AreEqual(null, db.QueryScalar<decimal?>(Select("decimal", 1)));
-        Assert.AreEqual(0, db.QueryScalar<decimal?>(Select("decimal", 2)));
-        Assert.AreEqual(55.89m, db.QueryScalar<decimal?>(Select("decimal", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<decimal?>(Select("decimal", 1)), Is.EqualTo(null));
+            Assert.That(db.QueryScalar<decimal?>(Select("decimal", 2)), Is.EqualTo(0));
+            Assert.That(db.QueryScalar<decimal?>(Select("decimal", 3)), Is.EqualTo(55.89m));
+        });
     }
 
     [Test]
     public void QueryScalarNullableDateTime()
     {
-        Assert.AreEqual(null, db.QueryScalar<DateTime?>(Select("DateTime", 1)));
-        Assert.AreEqual(new DateTime(1753, 1, 1, 0, 0, 0), db.QueryScalar<DateTime?>(Select("DateTime", 2)));
-        Assert.AreEqual(new DateTime(2018, 4, 2, 13, 14, 15), db.QueryScalar<DateTime?>(Select("DateTime", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<DateTime?>(Select("DateTime", 1)), Is.EqualTo(null));
+            Assert.That(db.QueryScalar<DateTime?>(Select("DateTime", 2)), Is.EqualTo(new DateTime(1753, 1, 1, 0, 0, 0)));
+            Assert.That(db.QueryScalar<DateTime?>(Select("DateTime", 3)), Is.EqualTo(new DateTime(2018, 4, 2, 13, 14, 15)));
+        });
     }
 
     [Test]
     public void QueryScalarNullableDateTimeStoredAsDateTime2()
     {
-        Assert.AreEqual(null, db.QueryScalar<DateTime?>(Select("DateTime2", 1)));
-        Assert.AreEqual(DateTime.MinValue, db.QueryScalar<DateTime?>(Select("DateTime2", 2)));
-        Assert.AreEqual(new DateTime(2023, 8, 11, 14, 9, 15), db.QueryScalar<DateTime?>(Select("DateTime2", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<DateTime?>(Select("DateTime2", 1)), Is.EqualTo(null));
+            Assert.That(db.QueryScalar<DateTime?>(Select("DateTime2", 2)), Is.EqualTo(DateTime.MinValue));
+            Assert.That(db.QueryScalar<DateTime?>(Select("DateTime2", 3)), Is.EqualTo(new DateTime(2023, 8, 11, 14, 9, 15)));
+        });
     }
 
     [Test]
     public void QueryScalarNullableDateOnly()
     {
-        Assert.AreEqual(null, db.QueryScalar<DateOnly?>(Select("Date", 1)));
-        Assert.AreEqual(DateOnly.MinValue, db.QueryScalar<DateOnly?>(Select("Date", 2)));
-        Assert.AreEqual(new DateOnly(2023, 8, 11), db.QueryScalar<DateOnly?>(Select("Date", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<DateOnly?>(Select("Date", 1)), Is.EqualTo(null));
+            Assert.That(db.QueryScalar<DateOnly?>(Select("Date", 2)), Is.EqualTo(DateOnly.MinValue));
+            Assert.That(db.QueryScalar<DateOnly?>(Select("Date", 3)), Is.EqualTo(new DateOnly(2023, 8, 11)));
+        });
     }
 
     [Test]
     public void QueryScalarNullableTimeOnly()
     {
-        Assert.AreEqual(null, db.QueryScalar<TimeOnly?>(Select("Time", 1)));
-        Assert.AreEqual(TimeOnly.MinValue, db.QueryScalar<TimeOnly?>(Select("Time", 2)));
-        Assert.AreEqual(new TimeOnly(14, 9, 15), db.QueryScalar<TimeOnly?>(Select("Time", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<TimeOnly?>(Select("Time", 1)), Is.EqualTo(null));
+            Assert.That(db.QueryScalar<TimeOnly?>(Select("Time", 2)), Is.EqualTo(TimeOnly.MinValue));
+            Assert.That(db.QueryScalar<TimeOnly?>(Select("Time", 3)), Is.EqualTo(new TimeOnly(14, 9, 15)));
+        });
     }
 
     [Test]
     public void QueryScalarNullableGuidStoredAsString()
     {
-        Assert.AreEqual(null, db.QueryScalar<Guid?>(Select("guid_as_string", 1)));
-        Assert.AreEqual(null, db.QueryScalar<Guid?>(Select("guid_as_string", 2)));
-        Assert.AreEqual(new Guid("7ca43d156e8749dfbaffdb241d0d494c"), db.QueryScalar<Guid?>(Select("guid_as_string", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<Guid?>(Select("guid_as_string", 1)), Is.EqualTo(null));
+            Assert.That(db.QueryScalar<Guid?>(Select("guid_as_string", 2)), Is.EqualTo(null));
+            Assert.That(db.QueryScalar<Guid?>(Select("guid_as_string", 3)), Is.EqualTo(new Guid("7ca43d156e8749dfbaffdb241d0d494c")));
+        });
     }
 
     [Test]
     public void QueryScalarNullableGuidStoredAsUniqueIdentifier()
     {
-        Assert.AreEqual(null, db.QueryScalar<Guid?>(Select("guid_as_uniqueid", 1)));
-        Assert.AreEqual(null, db.QueryScalar<Guid?>(Select("guid_as_uniqueid", 2)));
-        Assert.AreEqual(new Guid("7ca43d156e8749dfbaffdb241d0d494c"), db.QueryScalar<Guid?>(Select("guid_as_uniqueid", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<Guid?>(Select("guid_as_uniqueid", 1)), Is.EqualTo(null));
+            Assert.That(db.QueryScalar<Guid?>(Select("guid_as_uniqueid", 2)), Is.EqualTo(null));
+            Assert.That(db.QueryScalar<Guid?>(Select("guid_as_uniqueid", 3)), Is.EqualTo(new Guid("7ca43d156e8749dfbaffdb241d0d494c")));
+        });
     }
 
     [Test]
     public void QueryScalarNullableChar()
     {
-        Assert.AreEqual(null, db.QueryScalar<char?>(Select("char", 1)));
-        Assert.AreEqual(null, db.QueryScalar<char?>(Select("char", 2)));
-        Assert.AreEqual('c', db.QueryScalar<char?>(Select("char", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<char?>(Select("char", 1)), Is.EqualTo(null));
+            Assert.That(db.QueryScalar<char?>(Select("char", 2)), Is.EqualTo(null));
+            Assert.That(db.QueryScalar<char?>(Select("char", 3)), Is.EqualTo('c'));
+        });
     }
 
     [Test]
     public void QueryScalarNullableIntEnum()
     {
-        Assert.AreEqual(null, db.QueryScalar<Numbers?>(Select("int_enum", 1)));
-        Assert.AreEqual(Numbers.Zero, db.QueryScalar<Numbers?>(Select("int_enum", 2)));
-        Assert.AreEqual(Numbers.Three, db.QueryScalar<Numbers?>(Select("int_enum", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<Numbers?>(Select("int_enum", 1)), Is.EqualTo(null));
+            Assert.That(db.QueryScalar<Numbers?>(Select("int_enum", 2)), Is.EqualTo(Numbers.Zero));
+            Assert.That(db.QueryScalar<Numbers?>(Select("int_enum", 3)), Is.EqualTo(Numbers.Three));
+        });
     }
 
     [Test]
     public void QueryScalarNullableStringEnum()
     {
-        Assert.AreEqual(null, db.QueryScalar<Colors?>(Select("string_enum", 1)));
-        Assert.AreEqual(null, db.QueryScalar<Colors?>(Select("string_enum", 2)));
-        Assert.AreEqual(Colors.Green, db.QueryScalar<Colors?>(Select("string_enum", 3)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(db.QueryScalar<Colors?>(Select("string_enum", 1)), Is.EqualTo(null));
+            Assert.That(db.QueryScalar<Colors?>(Select("string_enum", 2)), Is.EqualTo(null));
+            Assert.That(db.QueryScalar<Colors?>(Select("string_enum", 3)), Is.EqualTo(Colors.Green));
+        });
     }
 
     [Test]
@@ -313,7 +428,7 @@ public class QueryScalarTests
 
         var result = db.QueryScalar<SemanticInt>(Select("int", 3));
 
-        Assert.AreEqual(3, result.Value);
+        Assert.That(result.Value, Is.EqualTo(3));
     }
 
     class SemanticInt

--- a/src/Carbonated.Data.SqlServer.Tests/QueryTests.cs
+++ b/src/Carbonated.Data.SqlServer.Tests/QueryTests.cs
@@ -17,12 +17,18 @@ public class QueryTests
         connector = new SqlServerDbConnector(TestConnectionString);
     }
 
+    [TearDown]
+    public void TearDown()
+    {
+        connector.Dispose();
+    }
+
     [Test]
     public void QueryBool()
     {
         var values = connector.Query<bool>("select [bool] from type_test order by id");
 
-        CollectionAssert.AreEqual(new bool[] { false, false, true }, values);
+        Assert.That(values, Is.EqualTo(new bool[] { false, false, true }).AsCollection);
     }
 
     [Test]
@@ -30,7 +36,7 @@ public class QueryTests
     {
         var values = connector.Query<byte>("select [byte] from type_test order by id");
 
-        CollectionAssert.AreEqual(new byte[] { 0, 0, 1 }, values);
+        Assert.That(values, Is.EqualTo(new byte[] { 0, 0, 1 }).AsCollection);
     }
 
     [Test]
@@ -38,7 +44,7 @@ public class QueryTests
     {
         var values = connector.Query<short>("select [short] from type_test order by id");
 
-        CollectionAssert.AreEqual(new short[] { 0, 0, 2 }, values);
+        Assert.That(values, Is.EqualTo(new short[] { 0, 0, 2 }).AsCollection);
     }
 
     [Test]
@@ -46,7 +52,7 @@ public class QueryTests
     {
         var values = connector.Query<int>("select [int] from type_test order by id");
 
-        CollectionAssert.AreEqual(new int[] { 0, 0, 3 }, values);
+        Assert.That(values, Is.EqualTo(new int[] { 0, 0, 3 }).AsCollection);
     }
 
     [Test]
@@ -54,7 +60,7 @@ public class QueryTests
     {
         var values = connector.Query<long>("select [long] from type_test order by id");
 
-        CollectionAssert.AreEqual(new long[] { 0, 0, 5 }, values);
+        Assert.That(values, Is.EqualTo(new long[] { 0, 0, 5 }).AsCollection);
     }
 
     [Test]
@@ -62,7 +68,7 @@ public class QueryTests
     {
         var values = connector.Query<float>("select [float] from type_test order by id");
 
-        CollectionAssert.AreEqual(new float[] { 0.0f, 0.0f, 8.13f }, values);
+        Assert.That(values, Is.EqualTo(new float[] { 0.0f, 0.0f, 8.13f }).AsCollection);
     }
 
     [Test]
@@ -70,7 +76,7 @@ public class QueryTests
     {
         var values = connector.Query<double>("select [double] from type_test order by id");
 
-        CollectionAssert.AreEqual(new double[] { 0.0, 0.0, 21.34 }, values);
+        Assert.That(values, Is.EqualTo(new double[] { 0.0, 0.0, 21.34 }).AsCollection);
     }
 
     [Test]
@@ -78,7 +84,7 @@ public class QueryTests
     {
         var values = connector.Query<decimal>("select [decimal] from type_test order by id");
 
-        CollectionAssert.AreEqual(new decimal[] { 0.0m, 0.0m, 55.89m }, values);
+        Assert.That(values, Is.EqualTo(new decimal[] { 0.0m, 0.0m, 55.89m }).AsCollection);
     }
 
     [Test]
@@ -89,10 +95,10 @@ public class QueryTests
         var expected = new DateTime[]
         {
             DateTime.MinValue,
-            new DateTime(1753, 1, 1, 0, 0, 0),
-            new DateTime(2018, 4, 2, 13, 14, 15)
+            new(1753, 1, 1, 0, 0, 0),
+            new(2018, 4, 2, 13, 14, 15)
         };
-        CollectionAssert.AreEqual(expected, values);
+        Assert.That(values, Is.EqualTo(expected).AsCollection);
     }
 
     [Test]
@@ -104,9 +110,9 @@ public class QueryTests
         {
             DateTime.MinValue,
             DateTime.MinValue,
-            new DateTime(2023, 8, 11, 14, 9, 15)
+            new(2023, 8, 11, 14, 9, 15)
         };
-        CollectionAssert.AreEqual(expected, values);
+        Assert.That(values, Is.EqualTo(expected).AsCollection);
     }
 
     [Test]
@@ -118,9 +124,9 @@ public class QueryTests
         {
             DateOnly.MinValue,
             DateOnly.MinValue,
-            new DateOnly(2023, 8, 11)
+            new(2023, 8, 11)
         };
-        CollectionAssert.AreEqual(expected, values);
+        Assert.That(values, Is.EqualTo(expected).AsCollection);
     }
 
     [Test]
@@ -132,9 +138,9 @@ public class QueryTests
         {
             TimeOnly.MinValue,
             TimeOnly.MinValue,
-            new TimeOnly(14, 9, 15)
+            new(14, 9, 15)
         };
-        CollectionAssert.AreEqual(expected, values);
+        Assert.That(values, Is.EqualTo(expected).AsCollection);
     }
 
     [Test]
@@ -146,9 +152,9 @@ public class QueryTests
         {
             Guid.Empty,
             Guid.Empty,
-            new Guid("7ca43d156e8749dfbaffdb241d0d494c")
+            new("7ca43d156e8749dfbaffdb241d0d494c")
         };
-        CollectionAssert.AreEqual(expected, values);
+        Assert.That(values, Is.EqualTo(expected).AsCollection);
     }
 
     [Test]
@@ -160,9 +166,9 @@ public class QueryTests
         {
             Guid.Empty,
             Guid.Empty,
-            new Guid("7ca43d156e8749dfbaffdb241d0d494c")
+            new("7ca43d156e8749dfbaffdb241d0d494c")
         };
-        CollectionAssert.AreEqual(expected, values);
+        Assert.That(values, Is.EqualTo(expected).AsCollection);
     }
 
     [Test]
@@ -170,7 +176,7 @@ public class QueryTests
     {
         var values = connector.Query<char>("select [char] from type_test order by id");
 
-        CollectionAssert.AreEqual(new char[] { '\0', '\0', 'c' }, values);
+        Assert.That(values, Is.EqualTo(new char[] { '\0', '\0', 'c' }).AsCollection);
     }
 
     [Test]
@@ -178,7 +184,7 @@ public class QueryTests
     {
         var values = connector.Query<string>("select [string] from type_test order by id");
 
-        CollectionAssert.AreEqual(new string[] { null, string.Empty, "str" }, values);
+        Assert.That(values, Is.EqualTo(new string[] { null, string.Empty, "str" }).AsCollection);
     }
 
     [Test]
@@ -192,7 +198,7 @@ public class QueryTests
             null,
             new byte[] { 0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10 }
         };
-        CollectionAssert.AreEqual(expected, values);
+        Assert.That(values, Is.EqualTo(expected).AsCollection);
     }
 
     [Test]
@@ -204,65 +210,74 @@ public class QueryTests
         var empties = entities[1];
         var values = entities[2];
 
-        Assert.IsFalse(nulls.Bool);
-        Assert.AreEqual(0, nulls.Byte);
-        Assert.AreEqual(0, nulls.Short);
-        Assert.AreEqual(0, nulls.Int);
-        Assert.AreEqual(0, nulls.Long);
-        Assert.AreEqual(0, nulls.Float);
-        Assert.AreEqual(0, nulls.Double);
-        Assert.AreEqual(0, nulls.Decimal);
-        Assert.AreEqual(DateTime.MinValue, nulls.DateTime);
-        Assert.AreEqual(DateTime.MinValue, nulls.DateTime2);
-        Assert.AreEqual(DateOnly.MinValue, nulls.Date);
-        Assert.AreEqual(TimeOnly.MinValue, nulls.Time);
-        Assert.AreEqual(Guid.Empty, nulls.GuidAsString);
-        Assert.AreEqual(Guid.Empty, nulls.GuidAsUniqueId);
-        Assert.AreEqual('\0', nulls.Char);
-        Assert.IsNull(nulls.String);
-        Assert.IsNull(nulls.ByteArray);
-        Assert.AreEqual(Numbers.Zero, nulls.IntEnum);
-        Assert.AreEqual(Colors.Red, nulls.StringEnum);
+        Assert.Multiple(() =>
+        {
+            Assert.That(nulls.Bool, Is.False);
+            Assert.That(nulls.Byte, Is.EqualTo(0));
+            Assert.That(nulls.Short, Is.EqualTo(0));
+            Assert.That(nulls.Int, Is.EqualTo(0));
+            Assert.That(nulls.Long, Is.EqualTo(0));
+            Assert.That(nulls.Float, Is.EqualTo(0));
+            Assert.That(nulls.Double, Is.EqualTo(0));
+            Assert.That(nulls.Decimal, Is.EqualTo(0));
+            Assert.That(nulls.DateTime, Is.EqualTo(DateTime.MinValue));
+            Assert.That(nulls.DateTime2, Is.EqualTo(DateTime.MinValue));
+            Assert.That(nulls.Date, Is.EqualTo(DateOnly.MinValue));
+            Assert.That(nulls.Time, Is.EqualTo(TimeOnly.MinValue));
+            Assert.That(nulls.GuidAsString, Is.EqualTo(Guid.Empty));
+            Assert.That(nulls.GuidAsUniqueId, Is.EqualTo(Guid.Empty));
+            Assert.That(nulls.Char, Is.EqualTo('\0'));
+            Assert.That(nulls.String, Is.Null);
+            Assert.That(nulls.ByteArray, Is.Null);
+            Assert.That(nulls.IntEnum, Is.EqualTo(Numbers.Zero));
+            Assert.That(nulls.StringEnum, Is.EqualTo(Colors.Red));
+        });
 
-        Assert.IsFalse(empties.Bool);
-        Assert.AreEqual(0, empties.Byte);
-        Assert.AreEqual(0, empties.Short);
-        Assert.AreEqual(0, empties.Int);
-        Assert.AreEqual(0, empties.Long);
-        Assert.AreEqual(0, empties.Float);
-        Assert.AreEqual(0, empties.Double);
-        Assert.AreEqual(0, empties.Decimal);
-        Assert.AreEqual(new DateTime(1753, 1, 1, 0, 0, 0), empties.DateTime);
-        Assert.AreEqual(DateTime.MinValue, empties.DateTime2);
-        Assert.AreEqual(DateOnly.MinValue, empties.Date);
-        Assert.AreEqual(TimeOnly.MinValue, empties.Time);
-        Assert.AreEqual(Guid.Empty, empties.GuidAsString);
-        Assert.AreEqual(Guid.Empty, empties.GuidAsUniqueId);
-        Assert.AreEqual('\0', empties.Char);
-        Assert.AreEqual(string.Empty, empties.String);
-        CollectionAssert.AreEqual(null, empties.ByteArray);
-        Assert.AreEqual(Numbers.Zero, empties.IntEnum);
-        Assert.AreEqual(Colors.Red, empties.StringEnum);
+        Assert.Multiple(() =>
+        {
+            Assert.That(empties.Bool, Is.False);
+            Assert.That(empties.Byte, Is.EqualTo(0));
+            Assert.That(empties.Short, Is.EqualTo(0));
+            Assert.That(empties.Int, Is.EqualTo(0));
+            Assert.That(empties.Long, Is.EqualTo(0));
+            Assert.That(empties.Float, Is.EqualTo(0));
+            Assert.That(empties.Double, Is.EqualTo(0));
+            Assert.That(empties.Decimal, Is.EqualTo(0));
+            Assert.That(empties.DateTime, Is.EqualTo(new DateTime(1753, 1, 1, 0, 0, 0)));
+            Assert.That(empties.DateTime2, Is.EqualTo(DateTime.MinValue));
+            Assert.That(empties.Date, Is.EqualTo(DateOnly.MinValue));
+            Assert.That(empties.Time, Is.EqualTo(TimeOnly.MinValue));
+            Assert.That(empties.GuidAsString, Is.EqualTo(Guid.Empty));
+            Assert.That(empties.GuidAsUniqueId, Is.EqualTo(Guid.Empty));
+            Assert.That(empties.Char, Is.EqualTo('\0'));
+            Assert.That(empties.String, Is.EqualTo(string.Empty));
+            Assert.That(empties.ByteArray, Is.EqualTo(null).AsCollection);
+            Assert.That(empties.IntEnum, Is.EqualTo(Numbers.Zero));
+            Assert.That(empties.StringEnum, Is.EqualTo(Colors.Red));
+        });
 
-        Assert.IsTrue(values.Bool);
-        Assert.AreEqual(1, values.Byte);
-        Assert.AreEqual(2, values.Short);
-        Assert.AreEqual(3, values.Int);
-        Assert.AreEqual(5, values.Long);
-        Assert.AreEqual(8.13f, values.Float);
-        Assert.AreEqual(21.34, values.Double);
-        Assert.AreEqual(55.89m, values.Decimal);
-        Assert.AreEqual(new DateTime(2018, 4, 2, 13, 14, 15), values.DateTime);
-        Assert.AreEqual(new DateTime(2023, 8, 11, 14, 09, 15), values.DateTime2);
-        Assert.AreEqual(new DateOnly(2023, 8, 11), values.Date);
-        Assert.AreEqual(new TimeOnly(14, 9, 15), values.Time);
-        Assert.AreEqual(new Guid("7ca43d156e8749dfbaffdb241d0d494c"), values.GuidAsString);
-        Assert.AreEqual(new Guid("7ca43d156e8749dfbaffdb241d0d494c"), values.GuidAsUniqueId);
-        Assert.AreEqual('c', values.Char);
-        Assert.AreEqual("str", values.String);
-        CollectionAssert.AreEqual(new byte[] { 0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10 }, values.ByteArray);
-        Assert.AreEqual(Numbers.Three, values.IntEnum);
-        Assert.AreEqual(Colors.Green, values.StringEnum);
+        Assert.Multiple(() =>
+        {
+            Assert.That(values.Bool, Is.True);
+            Assert.That(values.Byte, Is.EqualTo(1));
+            Assert.That(values.Short, Is.EqualTo(2));
+            Assert.That(values.Int, Is.EqualTo(3));
+            Assert.That(values.Long, Is.EqualTo(5));
+            Assert.That(values.Float, Is.EqualTo(8.13f));
+            Assert.That(values.Double, Is.EqualTo(21.34));
+            Assert.That(values.Decimal, Is.EqualTo(55.89m));
+            Assert.That(values.DateTime, Is.EqualTo(new DateTime(2018, 4, 2, 13, 14, 15)));
+            Assert.That(values.DateTime2, Is.EqualTo(new DateTime(2023, 8, 11, 14, 09, 15)));
+            Assert.That(values.Date, Is.EqualTo(new DateOnly(2023, 8, 11)));
+            Assert.That(values.Time, Is.EqualTo(new TimeOnly(14, 9, 15)));
+            Assert.That(values.GuidAsString, Is.EqualTo(new Guid("7ca43d156e8749dfbaffdb241d0d494c")));
+            Assert.That(values.GuidAsUniqueId, Is.EqualTo(new Guid("7ca43d156e8749dfbaffdb241d0d494c")));
+            Assert.That(values.Char, Is.EqualTo('c'));
+            Assert.That(values.String, Is.EqualTo("str"));
+            Assert.That(values.ByteArray, Is.EqualTo(new byte[] { 0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10 }).AsCollection);
+            Assert.That(values.IntEnum, Is.EqualTo(Numbers.Three));
+            Assert.That(values.StringEnum, Is.EqualTo(Colors.Green));
+        });
     }
 
 
@@ -271,7 +286,7 @@ public class QueryTests
     {
         var values = connector.Query<bool?>("select [bool] from type_test order by id");
 
-        CollectionAssert.AreEqual(new bool?[] { null, false, true }, values);
+        Assert.That(values, Is.EqualTo(new bool?[] { null, false, true }).AsCollection);
     }
 
     [Test]
@@ -279,7 +294,7 @@ public class QueryTests
     {
         var values = connector.Query<byte?>("select [byte] from type_test order by id");
 
-        CollectionAssert.AreEqual(new byte?[] { null, 0, 1 }, values);
+        Assert.That(values, Is.EqualTo(new byte?[] { null, 0, 1 }).AsCollection);
     }
 
     [Test]
@@ -287,7 +302,7 @@ public class QueryTests
     {
         var values = connector.Query<short?>("select [short] from type_test order by id");
 
-        CollectionAssert.AreEqual(new short?[] { null, 0, 2 }, values);
+        Assert.That(values, Is.EqualTo(new short?[] { null, 0, 2 }).AsCollection);
     }
 
     [Test]
@@ -295,7 +310,7 @@ public class QueryTests
     {
         var values = connector.Query<int>("select [int] from type_test order by id");
 
-        CollectionAssert.AreEqual(new int[] { 0, 0, 3 }, values);
+        Assert.That(values, Is.EqualTo(new int[] { 0, 0, 3 }).AsCollection);
     }
 
     [Test]
@@ -303,7 +318,7 @@ public class QueryTests
     {
         var values = connector.Query<long?>("select [long] from type_test order by id");
 
-        CollectionAssert.AreEqual(new long?[] { null, 0, 5 }, values);
+        Assert.That(values, Is.EqualTo(new long?[] { null, 0, 5 }).AsCollection);
     }
 
     [Test]
@@ -311,7 +326,7 @@ public class QueryTests
     {
         var values = connector.Query<float?>("select [float] from type_test order by id");
 
-        CollectionAssert.AreEqual(new float?[] { null, 0.0f, 8.13f }, values);
+        Assert.That(values, Is.EqualTo(new float?[] { null, 0.0f, 8.13f }).AsCollection);
     }
 
     [Test]
@@ -319,7 +334,7 @@ public class QueryTests
     {
         var values = connector.Query<double?>("select [double] from type_test order by id");
 
-        CollectionAssert.AreEqual(new double?[] { null, 0.0, 21.34 }, values);
+        Assert.That(values, Is.EqualTo(new double?[] { null, 0.0, 21.34 }).AsCollection);
     }
 
     [Test]
@@ -327,7 +342,7 @@ public class QueryTests
     {
         var values = connector.Query<decimal?>("select [decimal] from type_test order by id");
 
-        CollectionAssert.AreEqual(new decimal?[] { null, 0.0m, 55.89m }, values);
+        Assert.That(values, Is.EqualTo(new decimal?[] { null, 0.0m, 55.89m }).AsCollection);
     }
 
     [Test]
@@ -341,7 +356,7 @@ public class QueryTests
             new DateTime(1753, 1, 1, 0, 0, 0),
             new DateTime(2018, 4, 2, 13, 14, 15)
         };
-        CollectionAssert.AreEqual(expected, values);
+        Assert.That(values, Is.EqualTo(expected).AsCollection);
     }
 
     [Test]
@@ -355,7 +370,7 @@ public class QueryTests
             DateTime.MinValue,
             new DateTime(2023, 8, 11, 14, 9, 15)
         };
-        CollectionAssert.AreEqual(expected, values);
+        Assert.That(values, Is.EqualTo(expected).AsCollection);
     }
 
     [Test]
@@ -369,7 +384,7 @@ public class QueryTests
             DateOnly.MinValue,
             new DateOnly(2023, 8, 11)
         };
-        CollectionAssert.AreEqual(expected, values);
+        Assert.That(values, Is.EqualTo(expected).AsCollection);
     }
 
     [Test]
@@ -383,7 +398,7 @@ public class QueryTests
             TimeOnly.MinValue,
             new TimeOnly(14, 9, 15)
         };
-        CollectionAssert.AreEqual(expected, values);
+        Assert.That(values, Is.EqualTo(expected).AsCollection);
     }
 
     [Test]
@@ -397,7 +412,7 @@ public class QueryTests
             null,
             new Guid("7ca43d156e8749dfbaffdb241d0d494c")
         };
-        CollectionAssert.AreEqual(expected, values);
+        Assert.That(values, Is.EqualTo(expected).AsCollection);
     }
 
     [Test]
@@ -411,7 +426,7 @@ public class QueryTests
             null,
             new Guid("7ca43d156e8749dfbaffdb241d0d494c")
         };
-        CollectionAssert.AreEqual(expected, values);
+        Assert.That(values, Is.EqualTo(expected).AsCollection);
     }
 
     [Test]
@@ -419,7 +434,7 @@ public class QueryTests
     {
         var values = connector.Query<char?>("select [char] from type_test order by id");
 
-        CollectionAssert.AreEqual(new char?[] { null, null, 'c' }, values);
+        Assert.That(values, Is.EqualTo(new char?[] { null, null, 'c' }).AsCollection);
     }
 
     [Test]
@@ -431,58 +446,67 @@ public class QueryTests
         var empties = entities[1];
         var values = entities[2];
 
-        Assert.IsNull(nulls.Bool);
-        Assert.IsNull(nulls.Byte);
-        Assert.IsNull(nulls.Short);
-        Assert.IsNull(nulls.Int);
-        Assert.IsNull(nulls.Long);
-        Assert.IsNull(nulls.Float);
-        Assert.IsNull(nulls.Double);
-        Assert.IsNull(nulls.Decimal);
-        Assert.IsNull(nulls.DateTime);
-        Assert.IsNull(nulls.DateTime2);
-        Assert.IsNull(nulls.Date);
-        Assert.IsNull(nulls.Time);
-        Assert.IsNull(nulls.GuidAsString);
-        Assert.IsNull(nulls.GuidAsUniqueId);
-        Assert.IsNull(nulls.Char);
-        Assert.IsNull(nulls.IntEnum);
-        Assert.IsNull(nulls.StringEnum);
+        Assert.Multiple(() =>
+        {
+            Assert.That(nulls.Bool, Is.Null);
+            Assert.That(nulls.Byte, Is.Null);
+            Assert.That(nulls.Short, Is.Null);
+            Assert.That(nulls.Int, Is.Null);
+            Assert.That(nulls.Long, Is.Null);
+            Assert.That(nulls.Float, Is.Null);
+            Assert.That(nulls.Double, Is.Null);
+            Assert.That(nulls.Decimal, Is.Null);
+            Assert.That(nulls.DateTime, Is.Null);
+            Assert.That(nulls.DateTime2, Is.Null);
+            Assert.That(nulls.Date, Is.Null);
+            Assert.That(nulls.Time, Is.Null);
+            Assert.That(nulls.GuidAsString, Is.Null);
+            Assert.That(nulls.GuidAsUniqueId, Is.Null);
+            Assert.That(nulls.Char, Is.Null);
+            Assert.That(nulls.IntEnum, Is.Null);
+            Assert.That(nulls.StringEnum, Is.Null);
+        });
 
-        Assert.IsFalse(empties.Bool);
-        Assert.AreEqual(0, empties.Byte);
-        Assert.AreEqual(0, empties.Short);
-        Assert.AreEqual(0, empties.Int);
-        Assert.AreEqual(0, empties.Long);
-        Assert.AreEqual(0, empties.Float);
-        Assert.AreEqual(0, empties.Double);
-        Assert.AreEqual(0, empties.Decimal);
-        Assert.AreEqual(new DateTime(1753, 1, 1, 0, 0, 0), empties.DateTime);
-        Assert.AreEqual(DateTime.MinValue, empties.DateTime2);
-        Assert.AreEqual(DateOnly.MinValue, empties.Date);
-        Assert.AreEqual(TimeOnly.MinValue, empties.Time);
-        Assert.IsNull(empties.GuidAsString);
-        Assert.IsNull(empties.GuidAsUniqueId);
-        Assert.IsNull(empties.Char);
-        Assert.AreEqual(Numbers.Zero, empties.IntEnum);
-        Assert.IsNull(empties.StringEnum);
+        Assert.Multiple(() =>
+        {
+            Assert.That(empties.Bool, Is.False);
+            Assert.That(empties.Byte, Is.EqualTo(0));
+            Assert.That(empties.Short, Is.EqualTo(0));
+            Assert.That(empties.Int, Is.EqualTo(0));
+            Assert.That(empties.Long, Is.EqualTo(0));
+            Assert.That(empties.Float, Is.EqualTo(0));
+            Assert.That(empties.Double, Is.EqualTo(0));
+            Assert.That(empties.Decimal, Is.EqualTo(0));
+            Assert.That(empties.DateTime, Is.EqualTo(new DateTime(1753, 1, 1, 0, 0, 0)));
+            Assert.That(empties.DateTime2, Is.EqualTo(DateTime.MinValue));
+            Assert.That(empties.Date, Is.EqualTo(DateOnly.MinValue));
+            Assert.That(empties.Time, Is.EqualTo(TimeOnly.MinValue));
+            Assert.That(empties.GuidAsString, Is.Null);
+            Assert.That(empties.GuidAsUniqueId, Is.Null);
+            Assert.That(empties.Char, Is.Null);
+            Assert.That(empties.IntEnum, Is.EqualTo(Numbers.Zero));
+            Assert.That(empties.StringEnum, Is.Null);
+        });
 
-        Assert.IsTrue(values.Bool);
-        Assert.AreEqual(1, values.Byte);
-        Assert.AreEqual(2, values.Short);
-        Assert.AreEqual(3, values.Int);
-        Assert.AreEqual(5, values.Long);
-        Assert.AreEqual(8.13f, values.Float);
-        Assert.AreEqual(21.34, values.Double);
-        Assert.AreEqual(55.89m, values.Decimal);
-        Assert.AreEqual(new DateTime(2018, 4, 2, 13, 14, 15), values.DateTime);
-        Assert.AreEqual(new DateTime(2023, 8, 11, 14, 9, 15), values.DateTime2);
-        Assert.AreEqual(new DateOnly(2023, 8, 11), values.Date);
-        Assert.AreEqual(new TimeOnly(14, 9, 15), values.Time);
-        Assert.AreEqual(new Guid("7ca43d156e8749dfbaffdb241d0d494c"), values.GuidAsString);
-        Assert.AreEqual(new Guid("7ca43d156e8749dfbaffdb241d0d494c"), values.GuidAsUniqueId);
-        Assert.AreEqual('c', values.Char);
-        Assert.AreEqual(Numbers.Three, values.IntEnum);
-        Assert.AreEqual(Colors.Green, values.StringEnum);
+        Assert.Multiple(() =>
+        {
+            Assert.That(values.Bool, Is.True);
+            Assert.That(values.Byte, Is.EqualTo(1));
+            Assert.That(values.Short, Is.EqualTo(2));
+            Assert.That(values.Int, Is.EqualTo(3));
+            Assert.That(values.Long, Is.EqualTo(5));
+            Assert.That(values.Float, Is.EqualTo(8.13f));
+            Assert.That(values.Double, Is.EqualTo(21.34));
+            Assert.That(values.Decimal, Is.EqualTo(55.89m));
+            Assert.That(values.DateTime, Is.EqualTo(new DateTime(2018, 4, 2, 13, 14, 15)));
+            Assert.That(values.DateTime2, Is.EqualTo(new DateTime(2023, 8, 11, 14, 9, 15)));
+            Assert.That(values.Date, Is.EqualTo(new DateOnly(2023, 8, 11)));
+            Assert.That(values.Time, Is.EqualTo(new TimeOnly(14, 9, 15)));
+            Assert.That(values.GuidAsString, Is.EqualTo(new Guid("7ca43d156e8749dfbaffdb241d0d494c")));
+            Assert.That(values.GuidAsUniqueId, Is.EqualTo(new Guid("7ca43d156e8749dfbaffdb241d0d494c")));
+            Assert.That(values.Char, Is.EqualTo('c'));
+            Assert.That(values.IntEnum, Is.EqualTo(Numbers.Three));
+            Assert.That(values.StringEnum, Is.EqualTo(Colors.Green));
+        });
     }
 }

--- a/src/Carbonated.Data.SqlServer/Carbonated.Data.SqlServer.csproj
+++ b/src/Carbonated.Data.SqlServer/Carbonated.Data.SqlServer.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Carbonated.Data.SqlServer/Carbonated.Data.SqlServer.csproj
+++ b/src/Carbonated.Data.SqlServer/Carbonated.Data.SqlServer.csproj
@@ -5,10 +5,10 @@
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <Authors>Carbonated Software</Authors>
     <Description>SqlServer implementation of Carbonated Data.</Description>
-    <Copyright>© 2023 Carbonated Software</Copyright>
+    <Copyright>© 2024 Carbonated Software</Copyright>
     <PackageProjectUrl>https://github.com/CarbonatedSoftware/carbonated-data</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>

--- a/src/Carbonated.Data.Tests/Carbonated.Data.Tests.csproj
+++ b/src/Carbonated.Data.Tests/Carbonated.Data.Tests.csproj
@@ -7,10 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-	<PackageReference Include="NUnit" Version="3.13.3" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+	<PackageReference Include="NUnit" Version="4.0.1" />
+	<PackageReference Include="NUnit.Analyzers" Version="4.0.1">
+	  <PrivateAssets>all</PrivateAssets>
+	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	</PackageReference>
 	<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-	<PackageReference Include="coverlet.collector" Version="3.1.0" />
+	<PackageReference Include="coverlet.collector" Version="6.0.1">
+	  <PrivateAssets>all</PrivateAssets>
+	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	</PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Carbonated.Data.Tests/EntityDataReaderShould.cs
+++ b/src/Carbonated.Data.Tests/EntityDataReaderShould.cs
@@ -20,13 +20,19 @@ public class EntityDataReaderShould
 
         var edr = new EntityDataReader<Entity>(entities, propertyMapper);
 
-        Assert.That(edr.Read(), Is.True);
-        Assert.That(edr["Name"], Is.EqualTo("Foo"));
-        Assert.That(edr[2], Is.EqualTo("E1"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(edr.Read(), Is.True);
+            Assert.That(edr["Name"], Is.EqualTo("Foo"));
+            Assert.That(edr[2], Is.EqualTo("E1"));
+        });
 
-        Assert.That(edr.Read(), Is.True);
-        Assert.That(edr[1], Is.EqualTo("Bar"));
-        Assert.That(edr["Title"], Is.EqualTo("E2"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(edr.Read(), Is.True);
+            Assert.That(edr[1], Is.EqualTo("Bar"));
+            Assert.That(edr["Title"], Is.EqualTo("E2"));
+        });
 
         Assert.That(edr.Read(), Is.False);
     }
@@ -45,13 +51,19 @@ public class EntityDataReaderShould
 
        var edr = new EntityDataReader<EntityWithSemanticProperty>(entities, propertyMapper);
 
-        Assert.That(edr.Read(), Is.True);
-        Assert.That(edr[0], Is.EqualTo(1));
-        Assert.That(edr["agentno"], Is.EqualTo(86));
+        Assert.Multiple(() =>
+        {
+            Assert.That(edr.Read(), Is.True);
+            Assert.That(edr[0], Is.EqualTo(1));
+            Assert.That(edr["agentno"], Is.EqualTo(86));
+        });
 
-        Assert.That(edr.Read(), Is.True);
-        Assert.That(edr[0], Is.EqualTo(2));
-        Assert.That(edr["agentno"], Is.EqualTo(99));
+        Assert.Multiple(() =>
+        {
+            Assert.That(edr.Read(), Is.True);
+            Assert.That(edr[0], Is.EqualTo(2));
+            Assert.That(edr["agentno"], Is.EqualTo(99));
+        });
 
         Assert.That(edr.Read(), Is.False);
     }
@@ -72,15 +84,20 @@ public class EntityDataReaderShould
 
         Assert.That(edr.FieldCount, Is.EqualTo(2));
 
-        Assert.That(edr.Read(), Is.True);
-        Assert.That(edr[0], Is.EqualTo(1));
-        Assert.That(edr[1], Is.EqualTo("E1"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(edr.Read(), Is.True);
+            Assert.That(edr[0], Is.EqualTo(1));
+            Assert.That(edr[1], Is.EqualTo("E1"));
+        });
 
-        Assert.That(edr.Read(), Is.True);
-        Assert.That(edr["Id"], Is.EqualTo(2));
-        Assert.That(edr["Title"], Is.EqualTo("E2"));
-
-        Assert.That(() => edr["Name"], Throws.Exception);
+        Assert.Multiple(() =>
+        {
+            Assert.That(edr.Read(), Is.True);
+            Assert.That(edr["Id"], Is.EqualTo(2));
+            Assert.That(edr["Title"], Is.EqualTo("E2"));
+            Assert.That(() => edr["Name"], Throws.Exception);
+        });
 
         Assert.That(edr.Read(), Is.False);
     }
@@ -101,15 +118,20 @@ public class EntityDataReaderShould
 
         Assert.That(edr.FieldCount, Is.EqualTo(2));
 
-        Assert.That(edr.Read(), Is.True);
-        Assert.That(edr[0], Is.EqualTo(1));
-        Assert.That(edr[1], Is.EqualTo("E1"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(edr.Read(), Is.True);
+            Assert.That(edr[0], Is.EqualTo(1));
+            Assert.That(edr[1], Is.EqualTo("E1"));
+        });
 
-        Assert.That(edr.Read(), Is.True);
-        Assert.That(edr["Id"], Is.EqualTo(2));
-        Assert.That(edr["Title"], Is.EqualTo("E2"));
-
-        Assert.That(() => edr["Name"], Throws.Exception);
+        Assert.Multiple(() =>
+        {
+            Assert.That(edr.Read(), Is.True);
+            Assert.That(edr["Id"], Is.EqualTo(2));
+            Assert.That(edr["Title"], Is.EqualTo("E2"));
+            Assert.That(() => edr["Name"], Throws.Exception);
+        });
 
         Assert.That(edr.Read(), Is.False);
     }
@@ -130,15 +152,21 @@ public class EntityDataReaderShould
 
         Assert.That(edr.FieldCount, Is.EqualTo(3));
 
-        Assert.That(edr.Read(), Is.True);
-        Assert.That(edr[0], Is.EqualTo(1));
-        Assert.That(edr[1], Is.EqualTo("Foo"));
-        Assert.That(edr[2], Is.EqualTo("E1"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(edr.Read(), Is.True);
+            Assert.That(edr[0], Is.EqualTo(1));
+            Assert.That(edr[1], Is.EqualTo("Foo"));
+            Assert.That(edr[2], Is.EqualTo("E1"));
+        });
 
-        Assert.That(edr.Read(), Is.True);
-        Assert.That(edr["Id"], Is.EqualTo(2));
-        Assert.That(edr["Name"], Is.EqualTo("Bar"));
-        Assert.That(edr["Title"], Is.EqualTo("E2"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(edr.Read(), Is.True);
+            Assert.That(edr["Id"], Is.EqualTo(2));
+            Assert.That(edr["Name"], Is.EqualTo("Bar"));
+            Assert.That(edr["Title"], Is.EqualTo("E2"));
+        });
 
         Assert.That(edr.Read(), Is.False);
     }

--- a/src/Carbonated.Data.Tests/EntityReaderShould.cs
+++ b/src/Carbonated.Data.Tests/EntityReaderShould.cs
@@ -20,7 +20,7 @@ public class EntityReaderShould
 
         var inst = reader.First();
 
-        Assert.AreEqual(3, inst.Id);
+        Assert.That(inst.Id, Is.EqualTo(3));
     }
 
     [Test]
@@ -37,8 +37,11 @@ public class EntityReaderShould
         var reader = new EntityReader<Entity>(dataReader, mapper);
         var items = reader.Take(2).ToList();
 
-        Assert.AreEqual("John Q", items[0].Name);
-        Assert.AreEqual("Jane R", items[1].Name);
+        Assert.Multiple(() =>
+        {
+            Assert.That(items[0].Name, Is.EqualTo("John Q"));
+            Assert.That(items[1].Name, Is.EqualTo("Jane R"));
+        });
     }
 
     [Test]
@@ -55,8 +58,11 @@ public class EntityReaderShould
         var reader = new EntityReader<EntityWithSemanticProperty>(dataReader, mapper);
         var items = reader.ToList();
 
-        Assert.AreEqual(42, items[0].Id);
-        Assert.AreEqual(86, items[0].AgentNumber.Value);
+        Assert.Multiple(() =>
+        {
+            Assert.That(items[0].Id, Is.EqualTo(42));
+            Assert.That(items[0].AgentNumber.Value, Is.EqualTo(86));
+        });
     }
 
     [Test]
@@ -72,10 +78,10 @@ public class EntityReaderShould
 
         var reader = new EntityReader<Entity>(dataReader, mapper);
 
-        Assert.IsFalse(dataReader.IsClosed);
+        Assert.That(dataReader.IsClosed, Is.False);
 
         var items = reader.ToList();
 
-        Assert.IsTrue(dataReader.IsClosed);
+        Assert.That(dataReader.IsClosed, Is.True);
     }
 }

--- a/src/Carbonated.Data.Tests/MapperCollectionShould.cs
+++ b/src/Carbonated.Data.Tests/MapperCollectionShould.cs
@@ -21,7 +21,7 @@ public class MapperCollectionShould
     {
         mc.Configure<Entity>(record => new Entity());
 
-        Assert.IsInstanceOf<TypeMapper<Entity>>(mc.Get<Entity>());
+        Assert.That(mc.Get<Entity>(), Is.InstanceOf<TypeMapper<Entity>>());
     }
 
     [Test]
@@ -29,7 +29,7 @@ public class MapperCollectionShould
     {
         var mapper = mc.Configure<Entity>();
 
-        Assert.IsInstanceOf<PropertyMapper<Entity>>(mapper);
+        Assert.That(mapper, Is.InstanceOf<PropertyMapper<Entity>>());
     }
 
     [Test]
@@ -37,7 +37,7 @@ public class MapperCollectionShould
     {
         var mapper = mc.Configure<Entity>(PopulationCondition.Required);
 
-        Assert.IsInstanceOf<PropertyMapper<Entity>>(mapper);
+        Assert.That(mapper, Is.InstanceOf<PropertyMapper<Entity>>());
     }
 
     [Test]
@@ -45,7 +45,7 @@ public class MapperCollectionShould
     {
         mc.Configure<Entity>();
 
-        Assert.IsTrue(mc.HasMapper<Entity>());
+        Assert.That(mc.HasMapper<Entity>(), Is.True);
     }
 
     [Test]
@@ -53,51 +53,57 @@ public class MapperCollectionShould
     {
         mc.Configure<Entity>();
 
-        Assert.Throws<MappingException>(() => mc.Configure<Entity>());
+        Assert.That(() => mc.Configure<Entity>(), Throws.TypeOf<MappingException>());
     }
 
     [Test]
     public void AutoGenerateAndAddPropertyMapperDuringGetIfNotYetRegistered()
     {
-        Assert.IsFalse(mc.HasMapper<Entity>());
+        Assert.That(mc.HasMapper<Entity>(), Is.False);
 
         var mapper = mc.Get<Entity>();
 
-        Assert.IsTrue(mc.HasMapper<Entity>());
-        Assert.IsInstanceOf<PropertyMapper<Entity>>(mapper);
+        Assert.Multiple(() =>
+        {
+            Assert.That(mc.HasMapper<Entity>(), Is.True);
+            Assert.That(mapper, Is.InstanceOf<PropertyMapper<Entity>>());
+        });
     }
 
     [Test]
     public void HaveFrameworkTypeMappersBuiltIn()
     {
-        Assert.IsTrue(mc.HasMapper<bool>());
-        Assert.IsTrue(mc.HasMapper<byte>());
-        Assert.IsTrue(mc.HasMapper<short>());
-        Assert.IsTrue(mc.HasMapper<int>());
-        Assert.IsTrue(mc.HasMapper<long>());
-        Assert.IsTrue(mc.HasMapper<float>());
-        Assert.IsTrue(mc.HasMapper<double>());
-        Assert.IsTrue(mc.HasMapper<decimal>());
-        Assert.IsTrue(mc.HasMapper<DateTime>());
-        Assert.IsTrue(mc.HasMapper<DateOnly>());
-        Assert.IsTrue(mc.HasMapper<TimeOnly>());
-        Assert.IsTrue(mc.HasMapper<Guid>());
-        Assert.IsTrue(mc.HasMapper<char>());
-        Assert.IsTrue(mc.HasMapper<string>());
-        Assert.IsTrue(mc.HasMapper<byte[]>());
+        Assert.Multiple(() =>
+        {
+            Assert.That(mc.HasMapper<bool>(), Is.True);
+            Assert.That(mc.HasMapper<byte>(), Is.True);
+            Assert.That(mc.HasMapper<short>(), Is.True);
+            Assert.That(mc.HasMapper<int>(), Is.True);
+            Assert.That(mc.HasMapper<long>(), Is.True);
+            Assert.That(mc.HasMapper<float>(), Is.True);
+            Assert.That(mc.HasMapper<double>(), Is.True);
+            Assert.That(mc.HasMapper<decimal>(), Is.True);
+            Assert.That(mc.HasMapper<DateTime>(), Is.True);
+            Assert.That(mc.HasMapper<DateOnly>(), Is.True);
+            Assert.That(mc.HasMapper<TimeOnly>(), Is.True);
+            Assert.That(mc.HasMapper<Guid>(), Is.True);
+            Assert.That(mc.HasMapper<char>(), Is.True);
+            Assert.That(mc.HasMapper<string>(), Is.True);
+            Assert.That(mc.HasMapper<byte[]>(), Is.True);
 
-        Assert.IsTrue(mc.HasMapper<bool?>());
-        Assert.IsTrue(mc.HasMapper<byte?>());
-        Assert.IsTrue(mc.HasMapper<short?>());
-        Assert.IsTrue(mc.HasMapper<int?>());
-        Assert.IsTrue(mc.HasMapper<long?>());
-        Assert.IsTrue(mc.HasMapper<float?>());
-        Assert.IsTrue(mc.HasMapper<double?>());
-        Assert.IsTrue(mc.HasMapper<decimal?>());
-        Assert.IsTrue(mc.HasMapper<DateTime?>());
-        Assert.IsTrue(mc.HasMapper<DateOnly?>());
-        Assert.IsTrue(mc.HasMapper<TimeOnly?>());
-        Assert.IsTrue(mc.HasMapper<Guid?>());
-        Assert.IsTrue(mc.HasMapper<char?>());
+            Assert.That(mc.HasMapper<bool?>(), Is.True);
+            Assert.That(mc.HasMapper<byte?>(), Is.True);
+            Assert.That(mc.HasMapper<short?>(), Is.True);
+            Assert.That(mc.HasMapper<int?>(), Is.True);
+            Assert.That(mc.HasMapper<long?>(), Is.True);
+            Assert.That(mc.HasMapper<float?>(), Is.True);
+            Assert.That(mc.HasMapper<double?>(), Is.True);
+            Assert.That(mc.HasMapper<decimal?>(), Is.True);
+            Assert.That(mc.HasMapper<DateTime?>(), Is.True);
+            Assert.That(mc.HasMapper<DateOnly?>(), Is.True);
+            Assert.That(mc.HasMapper<TimeOnly?>(), Is.True);
+            Assert.That(mc.HasMapper<Guid?>(), Is.True);
+            Assert.That(mc.HasMapper<char?>(), Is.True);
+        });
     }
 }

--- a/src/Carbonated.Data.Tests/MapperCollectionShould.cs
+++ b/src/Carbonated.Data.Tests/MapperCollectionShould.cs
@@ -49,6 +49,16 @@ public class MapperCollectionShould
     }
 
     [Test]
+    public void KnowWhatValueConvertersHaveBeenAdded()
+    {
+        Assert.That(mc.HasValueConverter<SemanticInt>, Is.False);
+
+        mc.AddValueConverter(x => new SemanticInt((int)x));
+
+        Assert.That(mc.HasValueConverter<SemanticInt>(), Is.True);
+    }
+
+    [Test]
     public void ThrowOnConfigureIfTypeIsAlreadyRegistered()
     {
         mc.Configure<Entity>();

--- a/src/Carbonated.Data.Tests/PropertyMapperShould.cs
+++ b/src/Carbonated.Data.Tests/PropertyMapperShould.cs
@@ -16,7 +16,7 @@ public class PropertyMapperShould
     {
         var mapper = PropMapper<Entity>();
 
-        CollectionAssert.AreEqual(Strings("Id", "Name", "Title"), mapper.Mappings.Select(m => m.Field));
+        Assert.That(mapper.Mappings.Select(m => m.Field), Is.EqualTo(Strings("Id", "Name", "Title")).AsCollection);
     }
 
     [Test]
@@ -26,8 +26,8 @@ public class PropertyMapperShould
             .Map(x => x.Name, "nom");
 
         var fields = mapper.Mappings.Select(m => m.Field);
-        CollectionAssert.DoesNotContain(fields, "Name");
-        CollectionAssert.Contains(fields, "nom");
+        Assert.That(fields, Has.No.Member("Name"));
+        Assert.That(fields, Has.Member("nom"));
     }
 
     [Test]
@@ -35,8 +35,8 @@ public class PropertyMapperShould
     {
         var mapper = PropMapper<Entity>();
 
-        var ex = Assert.Throws<MappingException>(() => mapper.Map(x => x.Name, "Title"));
-        StringAssert.StartsWith("Field cannot be mapped to more than one property", ex.Message);
+        Assert.That(() => mapper.Map(x => x.Name, "Title"), Throws.InstanceOf<MappingException>()
+            .With.Message.StartsWith("Field cannot be mapped to more than one property"));
     }
 
     [Test]
@@ -44,7 +44,7 @@ public class PropertyMapperShould
     {
         var mapper = PropMapper<Entity>();
 
-        Assert.IsTrue(mapper.Mappings.All(m => m.Condition == PopulationCondition.Optional));
+        Assert.That(mapper.Mappings.All(m => m.Condition == PopulationCondition.Optional), Is.True);
     }
 
     [Test]
@@ -52,7 +52,7 @@ public class PropertyMapperShould
     {
         var mapper = PropMapper<Entity>(PopulationCondition.Required);
 
-        Assert.IsTrue(mapper.Mappings.All(m => m.Condition == PopulationCondition.Required));
+        Assert.That(mapper.Mappings.All(m => m.Condition == PopulationCondition.Required), Is.True);
     }
 
     [Test]
@@ -61,7 +61,7 @@ public class PropertyMapperShould
         var mapper = PropMapper<Entity>()
             .Ignore(x => x.Title);
 
-        Assert.IsTrue(mapper.Mappings.Single(m => m.Property.Name == "Title").IsIgnored);
+        Assert.That(mapper.Mappings.Single(m => m.Property.Name == "Title").IsIgnored, Is.True);
     }
 
     [Test]
@@ -76,9 +76,12 @@ public class PropertyMapperShould
         var nameMap = mapper.Mappings.Single(m => m.Property.Name == "Name");
         var titleMap = mapper.Mappings.Single(m => m.Property.Name == "Title");
 
-        Assert.AreEqual(PopulationCondition.NotNull, idMap.Condition);
-        Assert.AreEqual(PopulationCondition.Optional, nameMap.Condition);
-        Assert.AreEqual(PopulationCondition.Optional, titleMap.Condition);
+        Assert.Multiple(() =>
+        {
+            Assert.That(idMap.Condition, Is.EqualTo(PopulationCondition.NotNull));
+            Assert.That(nameMap.Condition, Is.EqualTo(PopulationCondition.Optional));
+            Assert.That(titleMap.Condition, Is.EqualTo(PopulationCondition.Optional));
+        });
     }
 
     [Test]
@@ -87,7 +90,7 @@ public class PropertyMapperShould
         var mapper = PropMapper<Entity>(PopulationCondition.Required)
             .Map(x => x.Name, "nom");
 
-        Assert.AreEqual(PopulationCondition.Required, mapper.Mappings.Single(m => m.Property.Name == "Name").Condition);
+        Assert.That(mapper.Mappings.Single(m => m.Property.Name == "Name").Condition, Is.EqualTo(PopulationCondition.Required));
     }
 
     [Test]
@@ -98,7 +101,7 @@ public class PropertyMapperShould
         var mapper = PropMapper<Entity>()
             .Map(x => x.Id, "id", customConverter);
 
-        Assert.AreSame(customConverter, mapper.Mappings.Single(m => m.Property.Name == "Id").FromDbConverter);
+        Assert.That(mapper.Mappings.Single(m => m.Property.Name == "Id").FromDbConverter, Is.SameAs(customConverter));
     }
 
     [Test]
@@ -109,7 +112,7 @@ public class PropertyMapperShould
         var mapper = PropMapper<Entity>()
             .AfterBinding(action);
 
-        Assert.AreSame(action, mapper.AfterBindAction);
+        Assert.That(mapper.AfterBindAction, Is.SameAs(action));
     }
 
     #region Instance activation and population
@@ -122,7 +125,7 @@ public class PropertyMapperShould
         var mapper = PropMapper<Entity>();
         var inst = mapper.CreateInstance(record);
 
-        Assert.AreEqual(new Entity(10, "John Q", "Tester"), inst);
+        Assert.That(inst, Is.EqualTo(new Entity(10, "John Q", "Tester")));
     }
 
     [Test]
@@ -135,7 +138,7 @@ public class PropertyMapperShould
             .Map(x => x.Title, "role");
         var inst = mapper.CreateInstance(record);
 
-        Assert.AreEqual(new Entity(10, "John Q", "Tester"), inst);
+        Assert.That(inst, Is.EqualTo(new Entity(10, "John Q", "Tester")));
     }
 
     [Test]
@@ -147,7 +150,7 @@ public class PropertyMapperShould
             .Map(x => x.Id, "id", v => v.ToString() == "ten" ? 10 : 0);
         var inst = mapper.CreateInstance(record);
 
-        Assert.AreEqual(new Entity(10, "John Q", "Tester"), inst);
+        Assert.That(inst, Is.EqualTo(new Entity(10, "John Q", "Tester")));
     }
 
     [Test]
@@ -159,7 +162,7 @@ public class PropertyMapperShould
             .AfterBinding((r, e) => e.Title = "override");
         var inst = mapper.CreateInstance(record);
 
-        Assert.AreEqual(new Entity(10, "John Q", "override"), inst);
+        Assert.That(inst, Is.EqualTo(new Entity(10, "John Q", "override")));
     }
 
     [Test]
@@ -171,7 +174,7 @@ public class PropertyMapperShould
             .Ignore(x => x.Title);
         var inst = mapper.CreateInstance(record);
 
-        Assert.AreEqual(new Entity(10, "John Q", null), inst);
+        Assert.That(inst, Is.EqualTo(new Entity(10, "John Q", null)));
     }
 
     [Test]
@@ -183,7 +186,7 @@ public class PropertyMapperShould
             .IgnoreOnLoad(x => x.Title);
         var inst = mapper.CreateInstance(record);
 
-        Assert.AreEqual(new Entity(10, "John Q", null), inst);
+        Assert.That(inst, Is.EqualTo(new Entity(10, "John Q", null)));
     }
 
     [Test]
@@ -195,7 +198,7 @@ public class PropertyMapperShould
             .IgnoreOnSave(x => x.Title);
         var inst = mapper.CreateInstance(record);
 
-        Assert.AreEqual(new Entity(10, "John Q", "Tester"), inst);
+        Assert.That(inst, Is.EqualTo(new Entity(10, "John Q", "Tester")));
     }
 
     [Test]
@@ -206,7 +209,7 @@ public class PropertyMapperShould
         var mapper = PropMapper<Entity>();
         var inst = mapper.CreateInstance(record);
 
-        Assert.AreEqual(new Entity(10, "John Q", "Tester"), inst);
+        Assert.That(inst, Is.EqualTo(new Entity(10, "John Q", "Tester")));
     }
 
     [Test]
@@ -217,7 +220,7 @@ public class PropertyMapperShould
         var mapper = PropMapper<NonNormalEntity>();
         var inst = mapper.CreateInstance(record);
 
-        Assert.AreEqual(50, inst.Entity_Id);
+        Assert.That(inst.Entity_Id, Is.EqualTo(50));
     }
 
     [Test]
@@ -228,8 +231,11 @@ public class PropertyMapperShould
         var mapper = PropMapper<IntDateEntity>();
         var inst = mapper.CreateInstance(record);
 
-        Assert.AreEqual(0, inst.IntProp);
-        Assert.AreEqual(DateTime.MinValue, inst.DateProp);
+        Assert.Multiple(() =>
+        {
+            Assert.That(inst.IntProp, Is.EqualTo(0));
+            Assert.That(inst.DateProp, Is.EqualTo(DateTime.MinValue));
+        });
     }
 
     [Test]
@@ -240,8 +246,11 @@ public class PropertyMapperShould
         var mapper = PropMapper<NullableIntDateEntity>();
         var inst = mapper.CreateInstance(record);
 
-        Assert.IsNull(inst.IntProp);
-        Assert.IsNull(inst.DateProp);
+        Assert.Multiple(() =>
+        {
+            Assert.That(inst.IntProp, Is.Null);
+            Assert.That(inst.DateProp, Is.Null);
+        });
     }
 
     [Test]
@@ -252,10 +261,13 @@ public class PropertyMapperShould
         var mapper = PropMapper<EnumEntity>();
         var inst = mapper.CreateInstance(record);
 
-        Assert.AreEqual(EnumEntity.Colors.Blue, inst.Color);
-        Assert.AreEqual(EnumEntity.Shapes.Square, inst.Shape);
-        Assert.AreEqual(EnumEntity.Colors.Red, inst.OtherColor);
-        Assert.AreEqual(EnumEntity.Shapes.Circle, inst.OtherShape);
+        Assert.Multiple(() =>
+        {
+            Assert.That(inst.Color, Is.EqualTo(EnumEntity.Colors.Blue));
+            Assert.That(inst.Shape, Is.EqualTo(EnumEntity.Shapes.Square));
+            Assert.That(inst.OtherColor, Is.EqualTo(EnumEntity.Colors.Red));
+            Assert.That(inst.OtherShape, Is.EqualTo(EnumEntity.Shapes.Circle));
+        });
     }
 
     [Test]
@@ -266,8 +278,8 @@ public class PropertyMapperShould
 
         var mapper = PropMapper<EnumEntity>();
 
-        Assert.Throws<BindingException>(() => mapper.CreateInstance(record1));
-        Assert.Throws<BindingException>(() => mapper.CreateInstance(record2));
+        Assert.That(() => mapper.CreateInstance(record1), Throws.TypeOf<BindingException>());
+        Assert.That(() => mapper.CreateInstance(record2), Throws.TypeOf<BindingException>());
     }
 
     [Test]
@@ -278,9 +290,12 @@ public class PropertyMapperShould
         var mapper = PropMapper<GuidEntity>();
         var inst = mapper.CreateInstance(record);
 
-        Assert.AreEqual(Guid.Empty, inst.Foo);
-        Assert.AreEqual(Guid.Empty, inst.Bar);
-        Assert.AreEqual(new Guid("10DB5BD9-A8CC-46E2-A5EB-791460B0B1CC"), inst.Baz);
+        Assert.Multiple(() =>
+        {
+            Assert.That(inst.Foo, Is.EqualTo(Guid.Empty));
+            Assert.That(inst.Bar, Is.EqualTo(Guid.Empty));
+            Assert.That(inst.Baz, Is.EqualTo(new Guid("10DB5BD9-A8CC-46E2-A5EB-791460B0B1CC")));
+        });
     }
 
     [Test]
@@ -291,9 +306,12 @@ public class PropertyMapperShould
         var mapper = PropMapper<NullableGuidEntity>();
         var inst = mapper.CreateInstance(record);
 
-        Assert.IsNull(inst.Foo);
-        Assert.IsNull(inst.Bar);
-        Assert.AreEqual(new Guid("10DB5BD9-A8CC-46E2-A5EB-791460B0B1CC"), inst.Baz);
+        Assert.Multiple(() =>
+        {
+            Assert.That(inst.Foo, Is.Null);
+            Assert.That(inst.Bar, Is.Null);
+            Assert.That(inst.Baz, Is.EqualTo(new Guid("10DB5BD9-A8CC-46E2-A5EB-791460B0B1CC")));
+        });
     }
 
     [Test]
@@ -303,7 +321,7 @@ public class PropertyMapperShould
 
         var mapper = PropMapper<GuidEntity>();
 
-        Assert.Throws<BindingException>(() => mapper.CreateInstance(record));
+        Assert.That(() => mapper.CreateInstance(record), Throws.TypeOf<BindingException>());
     }
 
     [Test]
@@ -314,7 +332,7 @@ public class PropertyMapperShould
         var mapper = PropMapper<CharEntity>();
         var inst = mapper.CreateInstance(record);
 
-        Assert.AreEqual(default(char), inst.CharProp);
+        Assert.That(inst.CharProp, Is.EqualTo(default(char)));
     }
 
     [Test]
@@ -325,9 +343,12 @@ public class PropertyMapperShould
         var mapper = PropMapper<ValueEntity>();
         var inst = mapper.CreateInstance(record);
 
-        Assert.AreEqual(42, inst.IntProp);
-        Assert.AreEqual(new DateTime(2018, 4, 2, 8, 30, 1), inst.DateProp);
-        Assert.AreEqual(3.14m, inst.DecimalProp);
+        Assert.Multiple(() =>
+        {
+            Assert.That(inst.IntProp, Is.EqualTo(42));
+            Assert.That(inst.DateProp, Is.EqualTo(new DateTime(2018, 4, 2, 8, 30, 1)));
+            Assert.That(inst.DecimalProp, Is.EqualTo(3.14m));
+        });
     }
 
     [Test]
@@ -338,8 +359,11 @@ public class PropertyMapperShould
         var mapper = PropMapper<JsonEntity>();
         var inst = mapper.CreateInstance(record);
 
-        Assert.AreEqual(inst.IntDateProp.IntProp, 5);
-        Assert.AreEqual(inst.IntDateProp.DateProp, new DateTime(2016, 1, 1, 16, 15, 0));
+        Assert.Multiple(() =>
+        {
+            Assert.That(inst.IntDateProp.IntProp, Is.EqualTo(5));
+            Assert.That(inst.IntDateProp.DateProp, Is.EqualTo(new DateTime(2016, 1, 1, 16, 15, 0)));
+        });
     }
 
     [Test]
@@ -354,14 +378,17 @@ public class PropertyMapperShould
         var inst2 = mapper.CreateInstance(record2);
         var inst3 = mapper.CreateInstance(record3);
 
-        CollectionAssert.AreEqual(new int[] { 1, 2, 3, 4 }, inst1.Numbers);
-        CollectionAssert.AreEqual(Strings("foo", "bar"), inst1.Strings);
+        Assert.Multiple(() =>
+        {
+            Assert.That(inst1.Numbers, Is.EqualTo(new int[] { 1, 2, 3, 4 }).AsCollection);
+            Assert.That(inst1.Strings, Is.EqualTo(Strings("foo", "bar")).AsCollection);
 
-        Assert.AreEqual(0, inst2.Numbers.Length);
-        Assert.AreEqual(0, inst2.Strings.Count());
+            Assert.That(inst2.Numbers, Is.Empty);
+            Assert.That(inst2.Strings.Count(), Is.EqualTo(0));
 
-        Assert.IsNull(inst3.Numbers);
-        Assert.IsNull(inst3.Strings);
+            Assert.That(inst3.Numbers, Is.Null);
+            Assert.That(inst3.Strings, Is.Null);
+        });
     }
 
     [Test]
@@ -372,7 +399,7 @@ public class PropertyMapperShould
         var mapper = PropMapper<Entity>()
             .Required(x => x.Name);
 
-        Assert.Throws<BindingException>(() => mapper.CreateInstance(record));
+        Assert.That(() => mapper.CreateInstance(record), Throws.TypeOf<BindingException>());
     }
 
     [Test]
@@ -383,7 +410,7 @@ public class PropertyMapperShould
         var mapper = PropMapper<Entity>()
             .NotNull(x => x.Name);
 
-        Assert.Throws<BindingException>(() => mapper.CreateInstance(record));
+        Assert.That(() => mapper.CreateInstance(record), Throws.TypeOf<BindingException>());
     }
 
     [Test]
@@ -398,7 +425,7 @@ public class PropertyMapperShould
 
         var inst = mapper.CreateInstance(record);
 
-        Assert.AreEqual(86, inst.AgentNumber.Value);
+        Assert.That(inst.AgentNumber.Value, Is.EqualTo(86));
     }
 
     #endregion

--- a/src/Carbonated.Data.Tests/PropertyMapperShould_WhenCreatingRecords.cs
+++ b/src/Carbonated.Data.Tests/PropertyMapperShould_WhenCreatingRecords.cs
@@ -13,8 +13,11 @@ public class PropertyMapperShould_WhenCreatingRecords
 
         var inst = mapper.CreateInstance(record);
 
-        Assert.That(inst.Name, Is.EqualTo("Moe"));
-        Assert.That(inst.Age, Is.EqualTo(31));
+        Assert.Multiple(() =>
+        {
+            Assert.That(inst.Name, Is.EqualTo("Moe"));
+            Assert.That(inst.Age, Is.EqualTo(31));
+        });
     }
 
     [Test]
@@ -25,8 +28,11 @@ public class PropertyMapperShould_WhenCreatingRecords
 
         var inst = mapper.CreateInstance(record);
 
-        Assert.That(inst.Name, Is.EqualTo("Larry"));
-        Assert.That(inst.Age, Is.EqualTo(34));
+        Assert.Multiple(() =>
+        {
+            Assert.That(inst.Name, Is.EqualTo("Larry"));
+            Assert.That(inst.Age, Is.EqualTo(34));
+        });
     }
 
     [Test]
@@ -37,8 +43,11 @@ public class PropertyMapperShould_WhenCreatingRecords
 
         var inst = mapper.CreateInstance(record);
 
-        Assert.That(inst.Name, Is.EqualTo("Curly"));
-        Assert.That(inst.Age, Is.EqualTo(28));
+        Assert.Multiple(() =>
+        {
+            Assert.That(inst.Name, Is.EqualTo("Curly"));
+            Assert.That(inst.Age, Is.EqualTo(28));
+        });
     }
 
     record RequiredRecord(string Name, int Age);

--- a/src/Carbonated.Data.Tests/RecordShould.cs
+++ b/src/Carbonated.Data.Tests/RecordShould.cs
@@ -12,8 +12,11 @@ public class RecordShould
     {
         var record = Record(("Foo", 1));
 
-        Assert.IsTrue(record.HasField("Foo"));
-        Assert.IsFalse(record.HasField("Oof"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(record.HasField("Foo"), Is.True);
+            Assert.That(record.HasField("Oof"), Is.False);
+        });
     }
 
     [Test]
@@ -21,7 +24,7 @@ public class RecordShould
     {
         var record = Record(("Foo", 1));
 
-        Assert.IsTrue(record.HasField("foo"));
+        Assert.That(record.HasField("foo"), Is.True);
     }
 
     [Test]
@@ -29,8 +32,11 @@ public class RecordShould
     {
         var record = Record(("Fo_o", 1));
 
-        Assert.IsTrue(record.HasField("Fo_o"));
-        Assert.IsTrue(record.HasField("foo"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(record.HasField("Fo_o"), Is.True);
+            Assert.That(record.HasField("foo"), Is.True);
+        });
     }
 
     [Test]
@@ -38,8 +44,11 @@ public class RecordShould
     {
         var record = Record(("foo", 1), ("f_oo", 2));
 
-        Assert.AreEqual(1, record.GetValue("foo"));
-        Assert.AreEqual(2, record.GetValue("f_oo"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(record.GetValue("foo"), Is.EqualTo(1));
+            Assert.That(record.GetValue("f_oo"), Is.EqualTo(2));
+        });
     }
 
     [Test]
@@ -47,9 +56,12 @@ public class RecordShould
     {
         var record = Record(("f_oo", 1), ("fo_o", 2));
 
-        Assert.IsFalse(record.HasField("foo"));
-        Assert.AreEqual(1, record.GetValue("f_oo"));
-        Assert.AreEqual(2, record.GetValue("fo_o"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(record.HasField("foo"), Is.False);
+            Assert.That(record.GetValue("f_oo"), Is.EqualTo(1));
+            Assert.That(record.GetValue("fo_o"), Is.EqualTo(2));
+        });
     }
 
     [Test]
@@ -57,7 +69,7 @@ public class RecordShould
     {
         var record = Record(("foo", 1));
 
-        Assert.AreEqual(1, record.GetValue("f_oo"));
+        Assert.That(record.GetValue("f_oo"), Is.EqualTo(1));
     }
 
     [Test]
@@ -65,7 +77,7 @@ public class RecordShould
     {
         var record = Record(("Foo", 1));
 
-        Assert.IsNull(record.GetValue("bar"));
+        Assert.That(record.GetValue("bar"), Is.Null);
     }
 
     [Test]
@@ -73,8 +85,11 @@ public class RecordShould
     {
         var record = Record(("Foo", 1));
 
-        Assert.AreEqual(0, record.GetIndex("foo"));
-        Assert.AreEqual(-1, record.GetIndex("bar"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(record.GetIndex("foo"), Is.EqualTo(0));
+            Assert.That(record.GetIndex("bar"), Is.EqualTo(-1));
+        });
     }
 
     [Test]
@@ -82,9 +97,12 @@ public class RecordShould
     {
         var record = Record(("bool", true), ("byte", (byte)1), ("char", 'a'));
 
-        Assert.AreEqual(true, record.GetBoolean("bool"));
-        Assert.AreEqual(1, record.GetByte("byte"));
-        Assert.AreEqual('a', record.GetChar("char"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(record.GetBoolean("bool"), Is.EqualTo(true));
+            Assert.That(record.GetByte("byte"), Is.EqualTo(1));
+            Assert.That(record.GetChar("char"), Is.EqualTo('a'));
+        });
     }
 
     [Test]
@@ -92,13 +110,19 @@ public class RecordShould
     {
         var record = Record(("bool1", true), ("bool2", DBNull.Value), ("dec1", 42m), ("dec2", DBNull.Value));
 
-        Assert.IsTrue(record.GetBooleanOrDefault("bool1"));
-        Assert.IsFalse(record.GetBooleanOrDefault("bool2"));
-        Assert.IsFalse(record.GetBooleanOrDefault("missing"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(record.GetBooleanOrDefault("bool1"), Is.True);
+            Assert.That(record.GetBooleanOrDefault("bool2"), Is.False);
+            Assert.That(record.GetBooleanOrDefault("missing"), Is.False);
+        });
 
-        Assert.AreEqual(42, record.GetDecimalOrDefault("dec1"));
-        Assert.AreEqual(0, record.GetDecimalOrDefault("dec2"));
-        Assert.AreEqual(0, record.GetDecimalOrDefault("missing"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(record.GetDecimalOrDefault("dec1"), Is.EqualTo(42));
+            Assert.That(record.GetDecimalOrDefault("dec2"), Is.EqualTo(0));
+            Assert.That(record.GetDecimalOrDefault("missing"), Is.EqualTo(0));
+        });
     }
 
     [Test]
@@ -106,12 +130,15 @@ public class RecordShould
     {
         var record = Record(("int1", 42), ("int2", DBNull.Value));
 
-        Assert.AreEqual(42, record.GetInt32OrDefault("int1"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(record.GetInt32OrDefault("int1"), Is.EqualTo(42));
 
-        Assert.AreEqual(0, record.GetInt32OrDefault("int2"));
-        Assert.AreEqual(76, record.GetInt32OrDefault("int2", 76));
+            Assert.That(record.GetInt32OrDefault("int2"), Is.EqualTo(0));
+            Assert.That(record.GetInt32OrDefault("int2", 76), Is.EqualTo(76));
 
-        Assert.AreEqual(0, record.GetInt32OrDefault("missing"));
-        Assert.AreEqual(99, record.GetInt32OrDefault("missing", 99));
+            Assert.That(record.GetInt32OrDefault("missing"), Is.EqualTo(0));
+            Assert.That(record.GetInt32OrDefault("missing", 99), Is.EqualTo(99));
+        });
     }
 }

--- a/src/Carbonated.Data.Tests/TupleSpike.cs
+++ b/src/Carbonated.Data.Tests/TupleSpike.cs
@@ -21,8 +21,11 @@ public class TupleSpike
 
         var inst = reader.First();
 
-        Assert.AreEqual(1, inst.Item1);
-        Assert.AreEqual("John", inst.Item2);
+        Assert.Multiple(() =>
+        {
+            Assert.That(inst.Item1, Is.EqualTo(1));
+            Assert.That(inst.Item2, Is.EqualTo("John"));
+        });
     }
 }
 

--- a/src/Carbonated.Data/Carbonated.Data.csproj
+++ b/src/Carbonated.Data/Carbonated.Data.csproj
@@ -4,10 +4,10 @@
     <TargetFramework>net6.0</TargetFramework>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <Authors>Carbonated Software</Authors>
     <Description>Simple data access library.</Description>
-    <Copyright>© 2023 Carbonated Software</Copyright>
+    <Copyright>© 2024 Carbonated Software</Copyright>
     <PackageProjectUrl>https://github.com/CarbonatedSoftware/carbonated-data</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>

--- a/src/Carbonated.Data/Internals/MapperCollection.cs
+++ b/src/Carbonated.Data/Internals/MapperCollection.cs
@@ -33,6 +33,16 @@ public class MapperCollection
     }
 
     /// <summary>
+    /// Indicates if a value converter for the specified type has been registered.
+    /// </summary>
+    /// <typeparam name="T">The type to check for.</typeparam>
+    /// <returns>true if a converter is registered; otherwise, false.</returns>
+    public bool HasValueConverter<T>()
+    {
+        return valueConverters.ContainsKey(typeof(T));
+    }
+
+    /// <summary>
     /// Gets a custom value converter if any can be found for the specified type.
     /// </summary>
     /// <typeparam name="T">The type to convert.</typeparam>


### PR DESCRIPTION
Added HasValueConverter() method to Mapper collection, allowing users to check if a converter for a given type has already been registered.

Also includes package dependency updates to latest versions.